### PR TITLE
Add jenkins_user table (#6) - Replaces #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.1.1 [2025-04-18]
+
+_Bug fixes_
+
+- Fixed Linux AMD64 plugin build failures for `Postgres 14 FDW`, `Postgres 15 FDW`, and `SQLite Extension` by upgrading GitHub Actions runners from `ubuntu-20.04` to `ubuntu-22.04`.
+
 ## v1.1.0 [2025-04-17]
 
 _Dependencies_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## v1.1.1 [2025-04-18]
-
-_Bug fixes_
-
-- Fixed Linux AMD64 plugin build failures for `Postgres 14 FDW`, `Postgres 15 FDW`, and `SQLite Extension` by upgrading GitHub Actions runners from `ubuntu-20.04` to `ubuntu-22.04`.
-
 ## v1.1.0 [2025-04-17]
 
 _Dependencies_

--- a/docs/tables/jenkins_user.md
+++ b/docs/tables/jenkins_user.md
@@ -1,0 +1,57 @@
+---
+title: "Steampipe Table: jenkins_user - Query Jenkins Users using SQL"
+description: "Allows users to query Jenkins Users, providing insights into users details such as its full_name, absolute_url and more."
+---
+
+# Table: jenkins_user – Query Jenkins Users Using SQL
+
+Jenkins users are entities configured within a Jenkins instance, typically representing developers, admins, or service accounts interacting with the Jenkins system. This table provides insights into the users configured in Jenkins, including their full names and profile URLs.
+
+## Table Usage Guide
+The jenkins_user table allows Jenkins administrators, DevOps engineers, and auditors to query details about users in a Jenkins instance. This includes identifying active users, reviewing user profiles, and auditing user access or existence.
+
+Each row in this table represents a single Jenkins user account retrieved from the Jenkins user database or API.
+
+## Examples
+
+### List all users with full profile URLs
+This query retrieves the full_name and absolute_url of all users configured in your Jenkins environment. It's useful for getting a complete overview of every user account, including their access URLs, which can help with user audits, role reviews, or general system documentation.
+
+```sql+postgres
+select
+  full_name,
+  absolute_url
+from
+  jenkins_user;
+```
+
+```sql+sqlite
+select
+  full_name,
+  absolute_url
+from
+  jenkins_user;
+```
+
+### List specfic users with full profile URLs
+This query filters the list of Jenkins users to show only those whose full_name contains the term "admin" (case-insensitive). It's particularly helpful for identifying administrative or privileged accounts, ensuring proper access control, and monitoring for potential misconfigured or unauthorized users.
+
+```sql+postgres
+select
+  full_name,
+  absolute_url
+from
+  jenkins_user
+where
+  full_name ilike '%admin%';
+```
+
+```sql+sqlite
+select
+  full_name,
+  absolute_url
+from
+  jenkins_user
+where
+  lower(full_name) like '%admin%';
+```

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.23.1
 toolchain go1.23.2
 
 require (
-	github.com/bndr/gojenkins v1.1.0
+
+	github.com/IvenGe/gojenkins v1.1.4
 	github.com/turbot/steampipe-plugin-sdk/v5 v5.11.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoIS
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/IvenGe/gojenkins v1.1.4 h1:6FVo5zA+iWLB8/Gdt9TKddF9JUTBVEUlkW3zQKt5P3k=
+github.com/IvenGe/gojenkins v1.1.4/go.mod h1:yQ/7f78LWd4lliW9AZpTkuNh/PO39jKjJYB1k24j1pg=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
@@ -209,8 +211,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
-github.com/bndr/gojenkins v1.1.0 h1:TWyJI6ST1qDAfH33DQb3G4mD8KkrBfyfSUoZBHQAvPI=
-github.com/bndr/gojenkins v1.1.0/go.mod h1:QeskxN9F/Csz0XV/01IC8y37CapKKWvOHa0UHLLX1fM=
 github.com/btubbs/datetime v0.1.1 h1:KuV+F9tyq/hEnezmKZNGk8dzqMVsId6EpFVrQCfA3To=
 github.com/btubbs/datetime v0.1.1/go.mod h1:n2BZ/2ltnRzNiz27aE3wUb2onNttQdC+WFxAoks5jJM=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=

--- a/jenkins/connect.go
+++ b/jenkins/connect.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"os"
 
-	"github.com/bndr/gojenkins"
+	"github.com/IvenGe/gojenkins"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
 
@@ -45,7 +45,7 @@ func connectUncached(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	// Error if the minimum config is not set
 	if server_url == "" || username == "" || password == "" {
 		return nil, errors.New("'server_url', 'username' and 'password' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe.")
-	}	
+	}
 
 	return gojenkins.CreateJenkins(nil, server_url, username, password).Init(ctx)
 }

--- a/jenkins/plugin.go
+++ b/jenkins/plugin.go
@@ -25,6 +25,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"jenkins_node":              tableJenkinsNode(),
 			"jenkins_pipeline":          tableJenkinsPipeline(),
 			"jenkins_plugin":            tableJenkinsPlugin(),
+			"jenkins_user":              tableJenkinsUser(),
 		},
 	}
 

--- a/jenkins/table_jenkins_folder.go
+++ b/jenkins/table_jenkins_folder.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/bndr/gojenkins"
+	"github.com/IvenGe/gojenkins"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 

--- a/jenkins/table_jenkins_freestyle_project.go
+++ b/jenkins/table_jenkins_freestyle_project.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/bndr/gojenkins"
+	"github.com/IvenGe/gojenkins"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 

--- a/jenkins/table_jenkins_job.go
+++ b/jenkins/table_jenkins_job.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/bndr/gojenkins"
+	"github.com/IvenGe/gojenkins"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 

--- a/jenkins/table_jenkins_pipeline.go
+++ b/jenkins/table_jenkins_pipeline.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/bndr/gojenkins"
+	"github.com/IvenGe/gojenkins"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 

--- a/jenkins/table_jenkins_user.go
+++ b/jenkins/table_jenkins_user.go
@@ -2,6 +2,7 @@ package jenkins
 
 import (
 	"context"
+	"time"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
@@ -21,6 +22,8 @@ func tableJenkinsUser() *plugin.Table {
 		Columns: []*plugin.Column{
 			{Name: "full_name", Type: proto.ColumnType_STRING, Hydrate: listJenkinsUsers, Description: "User's full name."},
 			{Name: "absolute_url", Type: proto.ColumnType_STRING, Hydrate: listJenkinsUsers, Transform: transform.FromField("AbsoluteURL"), Description: "User's absolute URL."},
+			{Name: "last_change", Type: proto.ColumnType_TIMESTAMP, Hydrate: listJenkinsUsers, Transform: transform.FromField("LastChange"), Description: "User's last change."},
+			{Name: "project", Type: proto.ColumnType_STRING, Hydrate: listJenkinsUsers, Description: "User's project."},
 		},
 	}
 }
@@ -37,9 +40,12 @@ func listJenkinsUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 		return nil, err
 	}
 	for _, user := range users.Raw.Users {
+		lastChange := time.UnixMilli(user.LastChange)
 		d.StreamListItem(ctx, map[string]interface{}{
 			"FullName":    user.User.FullName,
 			"AbsoluteURL": user.User.AbsoluteURL,
+			"LastChange":  lastChange,
+			"Project":     user.Project,
 		})
 	}
 	return nil, nil

--- a/jenkins/table_jenkins_user.go
+++ b/jenkins/table_jenkins_user.go
@@ -1,0 +1,45 @@
+package jenkins
+
+import (
+	"context"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+//// TABLE DEFINITION
+
+func tableJenkinsUser() *plugin.Table {
+	return &plugin.Table{
+		Name:        "jenkins_user",
+		Description: "An extension to Jenkins functionality provided separately from Jenkins Core.",
+		List: &plugin.ListConfig{
+			Hydrate: getlistJenkinsUsers,
+		},
+
+		Columns: []*plugin.Column{
+			{Name: "FullName", Type: proto.ColumnType_STRING, Hydrate: getlistJenkinsUsers, Description: "User's full name."},
+			{Name: "AbsoluteURL", Type: proto.ColumnType_STRING, Hydrate: getlistJenkinsUsers, Description: "User's absolute URL."},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func getlistJenkinsUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	client, err := Connect(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	users, err := client.GetAllUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, user := range users.Raw.Users {
+		d.StreamListItem(ctx, map[string]interface{}{
+			"FullName":    user.User.FullName,
+			"AbsoluteURL": user.User.AbsoluteURL,
+		})
+	}
+	return nil, nil
+}

--- a/jenkins/table_jenkins_user.go
+++ b/jenkins/table_jenkins_user.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 )
 
 //// TABLE DEFINITION
@@ -14,19 +15,19 @@ func tableJenkinsUser() *plugin.Table {
 		Name:        "jenkins_user",
 		Description: "An extension to Jenkins functionality provided separately from Jenkins Core.",
 		List: &plugin.ListConfig{
-			Hydrate: getlistJenkinsUsers,
+			Hydrate: listJenkinsUsers,
 		},
 
 		Columns: []*plugin.Column{
-			{Name: "FullName", Type: proto.ColumnType_STRING, Hydrate: getlistJenkinsUsers, Description: "User's full name."},
-			{Name: "AbsoluteURL", Type: proto.ColumnType_STRING, Hydrate: getlistJenkinsUsers, Description: "User's absolute URL."},
+			{Name: "full_name", Type: proto.ColumnType_STRING, Hydrate: listJenkinsUsers, Description: "User's full name."},
+			{Name: "absolute_url", Type: proto.ColumnType_STRING, Hydrate: listJenkinsUsers, Transform: transform.FromField("AbsoluteURL"), Description: "User's absolute URL."},
 		},
 	}
 }
 
 //// LIST FUNCTION
 
-func getlistJenkinsUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func listJenkinsUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	client, err := Connect(ctx, d)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR replaces #8, which had become stale and required rebasing.

Co-authored-by: IvenGe <47211504+IvenGe@users.noreply.github.com>
Co-authored-by: codenio <aananthk.mail@gmail.com>

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select full_name, absolute_url from jenkins_user limit 1
+------------+--------------------------------------------------------------+
| full_name  | absolute_url                                                 |
+------------+--------------------------------------------------------------+
| codenio    | https://jenkins.codenio.com/user/codenio@gmail.com           |
+------------+--------------------------------------------------------------+
```
</details>
